### PR TITLE
Add exception when sensor not found

### DIFF
--- a/monit/def_metrics.py
+++ b/monit/def_metrics.py
@@ -29,8 +29,11 @@ def _get_temp():
         return 'U'
 
 def _get_pitemp():
-    with open('/sys/class/thermal/thermal_zone0/temp', 'r') as f:
-        return '%.2f' % (float(f.read().strip())/1000, )
+    try:
+        with open('/sys/class/thermal/thermal_zone0/temp', 'r') as f:
+            return '%.2f' % (float(f.read().strip())/1000, )
+    except:
+        return 'U'
 
 def _get_uptime():
     with open('/proc/uptime', 'r') as f:


### PR DESCRIPTION
Even if it's a monit for Pi, it could be useful to except when there's no sensor on the system.
